### PR TITLE
Update readme to reccomend Go Mono

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,6 @@ Suggested font settings:
 {
     "editor.fontSize": 14.5,
     "editor.lineHeight": 17,
-    "editor.fontFamily": "Menlo",
+    "editor.fontFamily": "Go Mono",
 }
 ```


### PR DESCRIPTION
The recommended font should be Go Mono, not Menlo.

https://blog.golang.org/go-fonts